### PR TITLE
feat(US2.1): implement post-workout feedback system

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -524,7 +524,7 @@ class WorkoutFeedbackSerializer(serializers.ModelSerializer):
             'id', 'session', 'difficulty_rating', 'fatigue_level',
             'pain_reported', 'notes', 'created_at'
         ]
-        read_only_fields = ['created_at']
+        read_only_fields = ['id', 'session','created_at']
 
 
 # add schedule serializer

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -69,6 +69,6 @@ urlpatterns = [
     path('sessions/start/<str:date_str>/', views.start_workout_session),
     path('sessions/complete/<str:date_str>/', views.complete_workout_session),
     path('sessions/history/', views.workout_history),
-    
+    path('sessions/feedback/<str:date_str>/', views.workout_feedback),
 ]
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -853,23 +853,34 @@ def get_active_schedule(request):
     try:
         schedule = UserSchedule.objects.get(user=request.user, is_active=True)
         serializer = UserScheduleSerializer(schedule)
-        
+
         # Add calendar events for the next 4 weeks
         calendar_events = []
         start_date = schedule.start_date
         end_date = start_date + timedelta(days=27)  # 4 weeks = 28 days
+
         sessions = WorkoutSession.objects.filter(
             user=request.user,
             date__range=[start_date, end_date]
         )
-        status_by_date = {s.date.isoformat(): s.status for s in sessions}
+        sessions_list = list(sessions)
+        status_by_date = {s.date.isoformat(): s.status for s in sessions_list}
+
+        # Determine which dates already have feedback submitted
+        sessions_with_feedback = set(
+            WorkoutFeedback.objects.filter(
+                session__in=sessions_list
+            ).values_list('session__date', flat=True)
+        )
+        feedback_by_date = {d.isoformat(): True for d in sessions_with_feedback}
+
         days_of_week = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
-        
+
         for week in range(4):
             for day_index, day_name in enumerate(days_of_week):
                 event_date = start_date + timedelta(days=week * 7 + day_index)
                 section_ids = schedule.weekly_schedule.get(day_name, [])
-                
+
                 if not section_ids or section_ids == 'rest':
                     calendar_events.append({
                         'date': event_date.isoformat(),
@@ -877,59 +888,59 @@ def get_active_schedule(request):
                         'sections': [],
                         'section_type': 'rest',
                         'exercise_count': 0,
-                        'session_status': status_by_date.get(event_date.isoformat())
+                        'session_status': status_by_date.get(event_date.isoformat()),
+                        'has_feedback': feedback_by_date.get(event_date.isoformat(), False),
                     })
                 else:
                     # Get all sections for this day
                     sections = []
                     total_exercises = 0
-                    
+
                     # Handle both list and single ID formats
                     if not isinstance(section_ids, list):
                         section_ids = [section_ids] if section_ids != 'rest' else []
-                    
-                    # FIXED: Proper indentation here
+
                     for section_id in section_ids:
                         try:
                             section = ProgramSection.objects.get(id=section_id)
                             exercise_count = section.exercises.count()
                             total_exercises += exercise_count
-                            
+
                             sections.append({
                                 'id': section.id,
                                 'name': section.format,
                                 'type': section.type,
                                 'exercise_count': exercise_count,
-                                # NEW: Add program information
                                 'program_id': section.program.id,
                                 'program_name': section.program.name,
                                 'focus': section.program.focus,
                             })
                         except ProgramSection.DoesNotExist:
                             pass
-                    
-                    # FIXED: This needs to be at the same level as the for loop above
+
                     calendar_events.append({
                         'date': event_date.isoformat(),
                         'day': day_name,
                         'sections': sections,
                         'section_type': 'workout' if sections else 'rest',
                         'exercise_count': total_exercises,
-                        'session_status': status_by_date.get(event_date.isoformat())
-                        
+                        'session_status': status_by_date.get(event_date.isoformat()),
+                        'has_feedback': feedback_by_date.get(event_date.isoformat(), False),
                     })
-        
+
         return Response({
             'schedule': serializer.data,
             'calendar_events': calendar_events
         }, status=status.HTTP_200_OK)
-        
+
     except UserSchedule.DoesNotExist:
         return Response({
             'message': 'No active schedule found',
             'schedule': None,
             'calendar_events': []
         }, status=status.HTTP_200_OK)
+        
+        
 @api_view(['PATCH'])
 @authentication_classes([CsrfExemptSessionAuthentication])
 @permission_classes([IsAuthenticated])
@@ -963,6 +974,8 @@ def update_schedule_start_date(request, schedule_id):
             {"error": "Invalid date format. Use YYYY-MM-DD"},
             status=status.HTTP_400_BAD_REQUEST
         )
+    
+    
 @api_view(['GET'])
 @authentication_classes([CsrfExemptSessionAuthentication])
 @permission_classes([IsAuthenticated])
@@ -975,8 +988,11 @@ def get_workout_for_date(request, date_str):
             {"error": "Invalid date format. Use YYYY-MM-DD"},
             status=status.HTTP_400_BAD_REQUEST
         )
+
     session = WorkoutSession.objects.filter(user=request.user, date=target_date).first()
     session_status = session.status if session else None
+    has_feedback = WorkoutFeedback.objects.filter(session=session).exists() if session else False
+
     try:
         schedule = UserSchedule.objects.get(user=request.user, is_active=True)
     except UserSchedule.DoesNotExist:
@@ -984,25 +1000,23 @@ def get_workout_for_date(request, date_str):
             {"error": "No active schedule found"},
             status=status.HTTP_404_NOT_FOUND
         )
-    
-    # Calculate which day of the week this is
+
     day_name = target_date.strftime('%A').lower()
     section_ids = schedule.weekly_schedule.get(day_name, [])
-    
-    # Handle both list and single ID formats
+
     if not isinstance(section_ids, list):
         section_ids = [section_ids] if section_ids != 'rest' else []
-    
+
     if not section_ids or section_ids == 'rest':
         return Response({
             'date': date_str,
             'is_rest_day': True,
             'message': 'Rest day - recovery is important!',
             'workouts': [],
-            'session_status': session_status
+            'session_status': session_status,
+            'has_feedback': has_feedback,
         }, status=status.HTTP_200_OK)
-    
-    # Get all sections for this day
+
     workouts = []
     for section_id in section_ids:
         try:
@@ -1014,14 +1028,16 @@ def get_workout_for_date(request, date_str):
             })
         except ProgramSection.DoesNotExist:
             pass
-    
+
     return Response({
         'date': date_str,
         'is_rest_day': False,
         'workouts': workouts,
         'total_exercises': sum(len(w['section']['exercises']) for w in workouts),
-        'session_status': session_status
+        'session_status': session_status,
+        'has_feedback': has_feedback,
     }, status=status.HTTP_200_OK)
+
 
 @api_view(['GET'])
 @authentication_classes([CsrfExemptSessionAuthentication])
@@ -1064,7 +1080,7 @@ def start_workout_session(request, date_str):
         defaults={"status": "in_progress", "is_completed": False}
     )
 
-    # If it already existed and was completed, keep it completed (don’t “uncomplete”)
+    # If it already existed and was completed, keep it completed (don’t “incomplete”)
     if session.status != "completed":
         session.status = "in_progress"
         session.is_completed = False
@@ -1149,6 +1165,96 @@ def complete_workout_session(request, date_str):
         "notes": session.notes,
         "plan": session.plan.name if session.plan else None,
     }, status=status.HTTP_200_OK)
+    
+
+@api_view(['GET', 'POST'])
+@authentication_classes([CsrfExemptSessionAuthentication])
+@permission_classes([IsAuthenticated])
+def workout_feedback(request, date_str):
+    """GET existing feedback or POST new feedback for a completed session."""
+    try:
+        target_date = datetime.strptime(date_str, '%Y-%m-%d').date()
+    except ValueError:
+        return Response(
+            {"error": "Invalid date format. Use YYYY-MM-DD"},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    try:
+        session = WorkoutSession.objects.get(user=request.user, date=target_date)
+    except WorkoutSession.DoesNotExist:
+        return Response(
+            {"error": "No session found for this date"},
+            status=status.HTTP_404_NOT_FOUND
+        )
+
+    if request.method == 'GET':
+        try:
+            feedback = WorkoutFeedback.objects.get(session=session)
+            serializer = WorkoutFeedbackSerializer(feedback)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except WorkoutFeedback.DoesNotExist:
+            return Response(
+                {"error": "No feedback found for this session"},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+    # POST — validate session is completed first
+    if not session.is_completed:
+        return Response(
+            {"error": "Cannot submit feedback for an incomplete workout session"},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    # Validate difficulty_rating (required, 1–5)
+    difficulty_rating = request.data.get('difficulty_rating')
+    if difficulty_rating is None:
+        return Response(
+            {"error": "difficulty_rating is required"},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+    try:
+        difficulty_rating = int(difficulty_rating)
+        if not 1 <= difficulty_rating <= 5:
+            raise ValueError
+    except (ValueError, TypeError):
+        return Response(
+            {"error": "difficulty_rating must be an integer between 1 and 5"},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    # Validate fatigue_level (optional, 1–5 if provided)
+    fatigue_level = request.data.get('fatigue_level')
+    if fatigue_level is not None:
+        try:
+            fatigue_level = int(fatigue_level)
+            if not 1 <= fatigue_level <= 5:
+                raise ValueError
+        except (ValueError, TypeError):
+            return Response(
+                {"error": "fatigue_level must be an integer between 1 and 5"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+    try:
+        feedback = WorkoutFeedback.objects.get(session=session)
+        created = False
+    except WorkoutFeedback.DoesNotExist:
+        feedback = WorkoutFeedback(session=session)
+        created = True
+
+    feedback.difficulty_rating = difficulty_rating
+    feedback.fatigue_level = fatigue_level
+    feedback.pain_reported = bool(request.data.get('pain_reported', False))
+    feedback.notes = request.data.get('notes', '')
+    feedback.save()
+
+    serializer = WorkoutFeedbackSerializer(feedback)
+    return Response(
+        serializer.data,
+        status=status.HTTP_201_CREATED if created else status.HTTP_200_OK
+    )
+
 
 @api_view(['DELETE'])
 @authentication_classes([CsrfExemptSessionAuthentication])
@@ -1163,4 +1269,88 @@ def deactivate_schedule(request):
     return Response({
         'message': f'Deactivated {updated_count} schedule(s)',
         'count': updated_count
+    }, status=status.HTTP_200_OK)
+    
+@api_view(['GET'])
+@authentication_classes([CsrfExemptSessionAuthentication])
+@permission_classes([IsAuthenticated])
+def trainer_program_feedback(request, program_id): # to be used in US2.4 by Kevin (Weiqin Situ)
+    """
+    Return aggregated feedback for a trainer's program.
+    - Average difficulty and fatigue per program
+    - Individual session feedback entries (user identity anonymized)
+    - Weekly trend data (avg difficulty per week)
+    """
+    # Verify program exists and belongs to this trainer
+    try:
+        program = WorkoutPlan.objects.get(id=program_id, trainer=request.user)
+    except WorkoutPlan.DoesNotExist:
+        return Response(
+            {"error": "Program not found or you do not own this program"},
+            status=status.HTTP_404_NOT_FOUND
+        )
+
+    # Get all completed sessions for this program that have feedback
+    feedbacks = WorkoutFeedback.objects.filter(
+        session__plan=program,
+        session__is_completed=True
+    ).select_related('session')
+
+    if not feedbacks.exists():
+        return Response({
+            "program_id": program_id,
+            "program_name": program.name,
+            "total_responses": 0,
+            "avg_difficulty": None,
+            "avg_fatigue": None,
+            "pain_reported_count": 0,
+            "weekly_trends": [],
+            "entries": []
+        }, status=status.HTTP_200_OK)
+
+    # Aggregate stats
+    total = feedbacks.count()
+    avg_difficulty = round(
+        sum(f.difficulty_rating for f in feedbacks) / total, 2
+    )
+    fatigue_entries = [f.fatigue_level for f in feedbacks if f.fatigue_level is not None]
+    avg_fatigue = round(sum(fatigue_entries) / len(fatigue_entries), 2) if fatigue_entries else None
+    pain_count = feedbacks.filter(pain_reported=True).count()
+
+    # Weekly trend — group by ISO week, avg difficulty per week
+    from collections import defaultdict
+    weekly_data = defaultdict(list)
+    for f in feedbacks:
+        week_key = f.session.date.strftime('%Y-W%W')
+        weekly_data[week_key].append(f.difficulty_rating)
+    weekly_trends = [
+        {
+            "week": week,
+            "avg_difficulty": round(sum(vals) / len(vals), 2),
+            "response_count": len(vals)
+        }
+        for week, vals in sorted(weekly_data.items())
+    ]
+
+    # Individual entries — anonymized (no username, no user ID)
+    entries = [
+        {
+            "date": f.session.date.isoformat(),
+            "difficulty_rating": f.difficulty_rating,
+            "fatigue_level": f.fatigue_level,
+            "pain_reported": f.pain_reported,
+            "notes": f.notes,
+        }
+        for f in feedbacks.order_by('-session__date')
+    ]
+
+    return Response({
+        "program_id": program_id,
+        "program_name": program.name,
+        "total_responses": total,
+        "avg_difficulty": avg_difficulty,
+        "avg_fatigue": avg_fatigue,
+        "pain_reported_count": pain_count,
+        "weekly_trends": weekly_trends,
+        "entries": entries
     }, status=status.HTTP_200_OK)

--- a/frontend/src/app/schedule/page.tsx
+++ b/frontend/src/app/schedule/page.tsx
@@ -23,7 +23,7 @@ interface CalendarEvent {
   section_type: string;
   exercise_count: number;
   session_status?: 'in_progress' | 'completed' | null;
-
+  has_feedback?: boolean;
 }
 
 interface Program {
@@ -53,7 +53,7 @@ interface ScheduleResponse {
 const SchedulePage = () => {
   const router = useRouter();
   const { user } = useAuth();
-  
+
   const [scheduleData, setScheduleData] = useState<ScheduleResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
@@ -61,15 +61,23 @@ const SchedulePage = () => {
   const [showWorkoutModal, setShowWorkoutModal] = useState(false);
   const [editingStartDate, setEditingStartDate] = useState(false);
   const [newStartDate, setNewStartDate] = useState('');
-  
+
   // Notification state
   const [notification, setNotification] = useState<{
     type: 'success' | 'error' | 'info' | 'warning';
     message: string;
   } | null>(null);
-  
+
   // Confirm modal state
   const [showDeactivateConfirm, setShowDeactivateConfirm] = useState(false);
+
+  // Feedback form state
+  const [showFeedbackForm, setShowFeedbackForm] = useState(false);
+  const [feedbackRating, setFeedbackRating] = useState(0);
+  const [feedbackFatigue, setFeedbackFatigue] = useState<number | null>(null);
+  const [feedbackPain, setFeedbackPain] = useState(false);
+  const [feedbackNotes, setFeedbackNotes] = useState('');
+  const [submittingFeedback, setSubmittingFeedback] = useState(false);
 
   useEffect(() => {
     fetchSchedule();
@@ -79,14 +87,10 @@ const SchedulePage = () => {
     try {
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/api/schedule/active/`,
-        {
-          credentials: 'include',
-        }
+        { credentials: 'include' }
       );
-
       if (response.ok) {
         const data = await response.json();
-        console.log('Schedule data:', data);
         setScheduleData(data);
       }
     } catch (error) {
@@ -96,37 +100,35 @@ const SchedulePage = () => {
     }
   };
 
-  // Notification helpers
-  const showSuccess = (message: string) => {
-    setNotification({ type: 'success', message });
+  const showSuccess = (message: string) => setNotification({ type: 'success', message });
+  const showError = (message: string) => setNotification({ type: 'error', message });
+  const showInfo = (message: string) => setNotification({ type: 'info', message });
+
+  const resetFeedbackForm = () => {
+    setFeedbackRating(0);
+    setFeedbackFatigue(null);
+    setFeedbackPain(false);
+    setFeedbackNotes('');
   };
 
-  const showError = (message: string) => {
-    setNotification({ type: 'error', message });
-  };
-
-  const showInfo = (message: string) => {
-    setNotification({ type: 'info', message });
+  const handleCloseModal = () => {
+    setShowWorkoutModal(false);
+    setShowFeedbackForm(false);
+    resetFeedbackForm();
   };
 
   const handleUpdateStartDate = async () => {
     if (!newStartDate || !scheduleData?.schedule) return;
-
     try {
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/api/schedule/${scheduleData.schedule.id}/update-start-date/`,
         {
           method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({
-            start_date: newStartDate
-          })
+          body: JSON.stringify({ start_date: newStartDate }),
         }
       );
-
       if (response.ok) {
         showSuccess('Start date updated!');
         setEditingStartDate(false);
@@ -145,11 +147,8 @@ const SchedulePage = () => {
     try {
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/api/schedule/workout/${dateStr}/`,
-        {
-          credentials: 'include',
-        }
+        { credentials: 'include' }
       );
-
       if (response.ok) {
         const data = await response.json();
         setWorkoutDetail(data);
@@ -162,33 +161,68 @@ const SchedulePage = () => {
   };
 
   const startSession = async (dateStr: string) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/sessions/start/${dateStr}/`,
-    { method: 'POST', credentials: 'include' }
-  );
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/sessions/start/${dateStr}/`,
+      { method: 'POST', credentials: 'include' }
+    );
+    if (!res.ok) throw new Error('Failed to start session');
+    return res.json();
+  };
 
-  if (!res.ok) throw new Error('Failed to start session');
-  return res.json();
-};
+  const completeSession = async (dateStr: string) => {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/sessions/complete/${dateStr}/`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({}),
+      }
+    );
+    if (!res.ok) throw new Error('Failed to complete session');
+    return res.json();
+  };
 
-const completeSession = async (dateStr: string) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/sessions/complete/${dateStr}/`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({}),
+  const submitFeedback = async (dateStr: string) => {
+    if (feedbackRating === 0) {
+      showError('Please rate the difficulty before submitting.');
+      return;
     }
-  );
+    setSubmittingFeedback(true);
+    try {
+      const body: Record<string, any> = {
+        difficulty_rating: feedbackRating,
+        pain_reported: feedbackPain,
+        notes: feedbackNotes,
+      };
+      if (feedbackFatigue !== null) body.fatigue_level = feedbackFatigue;
 
-  if (!res.ok) throw new Error('Failed to complete session');
-  return res.json();
-};
-
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/sessions/feedback/${dateStr}/`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(body),
+        }
+      );
+      if (!res.ok) throw new Error('Failed to submit feedback');
+      showSuccess('Feedback submitted! 🙌');
+      setShowFeedbackForm(false);
+      setShowWorkoutModal(false);
+      resetFeedbackForm();
+      await fetchSchedule();
+    } catch {
+      showError('Could not submit feedback. Please try again.');
+    } finally {
+      setSubmittingFeedback(false);
+    }
+  };
 
   const handleDateClick = (event: CalendarEvent) => {
     setSelectedDate(event.date);
+    setShowFeedbackForm(false);
+    resetFeedbackForm();
     fetchWorkoutForDate(event.date);
   };
 
@@ -196,12 +230,8 @@ const completeSession = async (dateStr: string) => {
     try {
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/api/schedule/deactivate/`,
-        {
-          method: 'DELETE',
-          credentials: 'include',
-        }
+        { method: 'DELETE', credentials: 'include' }
       );
-
       if (response.ok) {
         showSuccess('Schedule cleared successfully');
         setTimeout(() => router.push('/trainer-programs'), 1500);
@@ -242,11 +272,9 @@ const completeSession = async (dateStr: string) => {
     return icons[focus?.toLowerCase()] || '🏋️';
   };
 
-  // Group events by week
   const groupEventsByWeek = (events: CalendarEvent[]) => {
     const weeks: CalendarEvent[][] = [];
     let currentWeek: CalendarEvent[] = [];
-
     events.forEach((event, index) => {
       currentWeek.push(event);
       if ((index + 1) % 7 === 0) {
@@ -254,11 +282,7 @@ const completeSession = async (dateStr: string) => {
         currentWeek = [];
       }
     });
-
-    if (currentWeek.length > 0) {
-      weeks.push(currentWeek);
-    }
-
+    if (currentWeek.length > 0) weeks.push(currentWeek);
     return weeks;
   };
 
@@ -284,16 +308,12 @@ const completeSession = async (dateStr: string) => {
             </button>
             <h1>My Workout Schedule</h1>
           </div>
-
           <div className="content">
             <div className="empty-state">
               <div className="empty-icon">📅</div>
               <h3>No Active Schedule</h3>
-              <p>You haven't selected a workout program yet.</p>
-              <button 
-                className="btn-primary"
-                onClick={() => router.push('/trainer-programs')}
-              >
+              <p>You haven&apos;t selected a workout program yet.</p>
+              <button className="btn-primary" onClick={() => router.push('/trainer-programs')}>
                 Browse Programs
               </button>
             </div>
@@ -305,11 +325,9 @@ const completeSession = async (dateStr: string) => {
 
   const { schedule, calendar_events } = scheduleData;
   const weeks = groupEventsByWeek(calendar_events);
-
-  // Get all unique focuses from all programs
-  const allFocuses = schedule.program_list ? 
-    [...new Set(schedule.program_list.flatMap(p => p.focus))] : 
-    [];
+  const allFocuses = schedule.program_list
+    ? [...new Set(schedule.program_list.flatMap((p) => p.focus))]
+    : [];
 
   return (
     <ProtectedRoute>
@@ -338,22 +356,18 @@ const completeSession = async (dateStr: string) => {
                   </div>
                 )}
               </div>
-              <button 
-                className="btn-deactivate"
-                onClick={() => setShowDeactivateConfirm(true)}
-              >
+              <button className="btn-deactivate" onClick={() => setShowDeactivateConfirm(true)}>
                 🗑️ Clear Schedule
               </button>
             </div>
 
-            {/* Show all programs in schedule - CLICKABLE */}
             {schedule.program_list && schedule.program_list.length > 0 && (
               <div className="programs-in-schedule">
                 <h4>Programs in Schedule ({schedule.program_list.length})</h4>
                 <div className="program-chips">
                   {schedule.program_list.map((program) => (
-                    <div 
-                      key={program.id} 
+                    <div
+                      key={program.id}
                       className="program-chip program-chip-clickable"
                       onClick={() => router.push(`/program/${program.id}`)}
                     >
@@ -373,14 +387,13 @@ const completeSession = async (dateStr: string) => {
                 <div className="stat-content">
                   <span className="stat-label">Trainers</span>
                   <span className="stat-value">
-                    {schedule.program_list && schedule.program_list.length > 0 
-                      ? [...new Set(schedule.program_list.map(p => p.trainer_name))].join(', ')
+                    {schedule.program_list && schedule.program_list.length > 0
+                      ? [...new Set(schedule.program_list.map((p) => p.trainer_name))].join(', ')
                       : 'N/A'}
                   </span>
                 </div>
               </div>
 
-              {/* EDITABLE START DATE */}
               <div className="stat-box">
                 <span className="stat-icon">📅</span>
                 <div className="stat-content">
@@ -395,27 +408,19 @@ const completeSession = async (dateStr: string) => {
                         min={new Date().toISOString().split('T')[0]}
                       />
                       <div className="date-edit-buttons">
-                        <button className="btn-save-date" onClick={handleUpdateStartDate}>
-                          ✓
-                        </button>
-                        <button 
-                          className="btn-cancel-date" 
-                          onClick={() => {
-                            setEditingStartDate(false);
-                            setNewStartDate('');
-                          }}
+                        <button className="btn-save-date" onClick={handleUpdateStartDate}>✓</button>
+                        <button
+                          className="btn-cancel-date"
+                          onClick={() => { setEditingStartDate(false); setNewStartDate(''); }}
                         >
                           ✕
                         </button>
                       </div>
                     </div>
                   ) : (
-                    <div 
-                      className="stat-value-editable" 
-                      onClick={() => {
-                        setEditingStartDate(true);
-                        setNewStartDate(schedule.start_date);
-                      }}
+                    <div
+                      className="stat-value-editable"
+                      onClick={() => { setEditingStartDate(true); setNewStartDate(schedule.start_date); }}
                     >
                       {new Date(schedule.start_date).toLocaleDateString()}
                       <span className="edit-icon">✏️</span>
@@ -439,7 +444,7 @@ const completeSession = async (dateStr: string) => {
           {/* Calendar */}
           <div className="calendar-section">
             <h3 className="calendar-title">4-Week Schedule</h3>
-            
+
             {weeks.map((week, weekIndex) => (
               <div key={weekIndex} className="calendar-week">
                 <div className="week-header">
@@ -458,12 +463,8 @@ const completeSession = async (dateStr: string) => {
                     >
                       <div className="day-header">
                         <span className="day-name">{event.day}</span>
-
-                        <span className="day-date">
-                          {new Date(event.date).getDate()}
-                        </span>
+                        <span className="day-date">{new Date(event.date).getDate()}</span>
                       </div>
-
 
                       <div className="day-content">
                         {event.section_type === 'rest' ? (
@@ -474,15 +475,13 @@ const completeSession = async (dateStr: string) => {
                         ) : (
                           <div className="workout-indicator">
                             <span className="workout-icon">🏋️</span>
-
-                            {/* Program info in simplified format */}
                             {event.sections && event.sections.length > 0 && (
                               <div className="workout-programs-table">
                                 {event.sections.map((section, idx) => (
                                   <div key={idx} className="program-row">
                                     <div className="program-name-col">
                                       <div className="program-name-line">
-                                        <a 
+                                        <a
                                           href={`/program/${section.program_id}`}
                                           className="program-link"
                                           onClick={(e) => {
@@ -498,19 +497,14 @@ const completeSession = async (dateStr: string) => {
                                           {typeof section.focus === 'string'
                                             ? section.focus
                                             : Array.isArray(section.focus)
-                                              ? (section.focus as string[]).slice(0, 2).join(', ')
-                                              : 'N/A'}
+                                            ? (section.focus as string[]).slice(0, 2).join(', ')
+                                            : 'N/A'}
                                         </span>
-
                                         {event.session_status === 'completed' && (
-                                          <span className="program-complete-badge">
-                                            ✅ Complete
-                                          </span>
+                                          <span className="program-complete-badge">✅ Complete</span>
                                         )}
                                         {event.session_status === 'in_progress' && (
-                                          <span className="program-inprogress-badge">
-                                           In Progress
-                                          </span>
+                                          <span className="program-inprogress-badge">In Progress</span>
                                         )}
                                       </div>
                                     </div>
@@ -518,10 +512,7 @@ const completeSession = async (dateStr: string) => {
                                 ))}
                               </div>
                             )}
-
-                            <div className="total-count">
-                              {event.exercise_count} total
-                            </div>
+                            <div className="total-count">{event.exercise_count} total</div>
                           </div>
                         )}
                       </div>
@@ -534,18 +525,17 @@ const completeSession = async (dateStr: string) => {
 
           {/* Workout Detail Modal */}
           {showWorkoutModal && workoutDetail ? (
-            <div className="modal-overlay" onClick={() => setShowWorkoutModal(false)}>
+            <div className="modal-overlay" onClick={handleCloseModal}>
               <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                 <div className="modal-header">
                   <h3>
-                    {workoutDetail.is_rest_day ? '😴 Rest Day' : '🏋️ Workout Day'}
+                    {showFeedbackForm
+                      ? '📝 Rate Your Workout'
+                      : workoutDetail.is_rest_day
+                      ? '😴 Rest Day'
+                      : '🏋️ Workout Day'}
                   </h3>
-                  <button 
-                    className="modal-close"
-                    onClick={() => setShowWorkoutModal(false)}
-                  >
-                    ✕
-                  </button>
+                  <button className="modal-close" onClick={handleCloseModal}>✕</button>
                 </div>
 
                 <div className="modal-body">
@@ -564,93 +554,212 @@ const completeSession = async (dateStr: string) => {
                     </div>
                   ) : (
                     <>
-                      {workoutDetail.workouts && workoutDetail.workouts.map((workout: any, workoutIdx: number) => (
-                        <div key={workoutIdx} className="workout-section-detail">
-                          <h4 className="workout-program-name">
-                            {workout.program_name} - {workout.section.format}
-                          </h4>
-                          
-                          {workout.section.exercises && workout.section.exercises.length > 0 && (
-                            <div className="exercises-section">
-                              {workout.section.exercises.map((exercise: any, index: number) => (
-                                <div key={exercise.id} className="exercise-detail">
-                                  <div className="exercise-detail-header">
-                                    <span className="exercise-number">{index + 1}</span>
-                                    <h5>{exercise.name}</h5>
-                                  </div>
-
-                                  <table className="sets-table">
-                                    <thead>
-                                      <tr>
-                                        <th>Set</th>
-                                        <th>Reps</th>
-                                        <th>Time</th>
-                                        <th>Rest</th>
-                                      </tr>
-                                    </thead>
-                                    <tbody>
-                                      {exercise.sets.map((set: any) => (
-                                        <tr key={set.id}>
-                                          <td>{set.set_number}</td>
-                                          <td>{set.reps || '-'}</td>
-                                          <td>{set.time ? formatTime(set.time) : '-'}</td>
-                                          <td>{formatTime(set.rest)}</td>
+                      {/* Exercise details — hidden while feedback form is active */}
+                      {!showFeedbackForm &&
+                        workoutDetail.workouts &&
+                        workoutDetail.workouts.map((workout: any, workoutIdx: number) => (
+                          <div key={workoutIdx} className="workout-section-detail">
+                            <h4 className="workout-program-name">
+                              {workout.program_name} - {workout.section.format}
+                            </h4>
+                            {workout.section.exercises && workout.section.exercises.length > 0 && (
+                              <div className="exercises-section">
+                                {workout.section.exercises.map((exercise: any, index: number) => (
+                                  <div key={exercise.id} className="exercise-detail">
+                                    <div className="exercise-detail-header">
+                                      <span className="exercise-number">{index + 1}</span>
+                                      <h5>{exercise.name}</h5>
+                                    </div>
+                                    <table className="sets-table">
+                                      <thead>
+                                        <tr>
+                                          <th>Set</th>
+                                          <th>Reps</th>
+                                          <th>Time</th>
+                                          <th>Rest</th>
                                         </tr>
-                                      ))}
-                                    </tbody>
-                                  </table>
-                                </div>
+                                      </thead>
+                                      <tbody>
+                                        {exercise.sets.map((set: any) => (
+                                          <tr key={set.id}>
+                                            <td>{set.set_number}</td>
+                                            <td>{set.reps || '-'}</td>
+                                            <td>{set.time ? formatTime(set.time) : '-'}</td>
+                                            <td>{formatTime(set.rest)}</td>
+                                          </tr>
+                                        ))}
+                                      </tbody>
+                                    </table>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        ))}
+
+                      {/* ── FEEDBACK FORM ── */}
+                      {showFeedbackForm && (
+                        <div className="feedback-form">
+                          {/* Difficulty — required */}
+                          <div className="feedback-section">
+                            <label className="feedback-label">
+                              Difficulty <span className="feedback-required">*</span>
+                            </label>
+                            <div className="rating-buttons">
+                              {[1, 2, 3, 4, 5].map((n) => (
+                                <button
+                                  key={n}
+                                  className={`rating-btn ${feedbackRating === n ? 'rating-btn-active' : ''}`}
+                                  onClick={() => setFeedbackRating(n)}
+                                >
+                                  {n}
+                                </button>
                               ))}
                             </div>
+                            <div className="rating-scale-labels">
+                              <span>Very Easy</span>
+                              <span>Very Hard</span>
+                            </div>
+                          </div>
+
+                          {/* Fatigue — optional */}
+                          <div className="feedback-section">
+                            <label className="feedback-label">
+                              Fatigue Level{' '}
+                              <span className="feedback-optional">(optional)</span>
+                            </label>
+                            <div className="rating-buttons">
+                              {[1, 2, 3, 4, 5].map((n) => (
+                                <button
+                                  key={n}
+                                  className={`rating-btn ${feedbackFatigue === n ? 'rating-btn-active' : ''}`}
+                                  onClick={() =>
+                                    setFeedbackFatigue(feedbackFatigue === n ? null : n)
+                                  }
+                                >
+                                  {n}
+                                </button>
+                              ))}
+                            </div>
+                            <div className="rating-scale-labels">
+                              <span>Not Tired</span>
+                              <span>Exhausted</span>
+                            </div>
+                          </div>
+
+                          {/* Pain — optional toggle */}
+                          <div className="feedback-section feedback-section-inline">
+                            <label className="feedback-label">Any pain or discomfort?</label>
+                            <button
+                              className={`toggle-pain-btn ${feedbackPain ? 'toggle-pain-yes' : 'toggle-pain-no'}`}
+                              onClick={() => setFeedbackPain(!feedbackPain)}
+                            >
+                              {feedbackPain ? '⚠️ Yes' : 'No'}
+                            </button>
+                          </div>
+
+                          {/* Notes — optional */}
+                          <div className="feedback-section">
+                            <label className="feedback-label">
+                              Notes{' '}
+                              <span className="feedback-optional">(optional)</span>
+                            </label>
+                            <textarea
+                              className="feedback-textarea"
+                              placeholder="How did it go? Any observations..."
+                              value={feedbackNotes}
+                              onChange={(e) => setFeedbackNotes(e.target.value)}
+                              rows={3}
+                            />
+                          </div>
+
+                          <div className="feedback-actions">
+                            <button
+                              className="btn-skip-feedback"
+                              onClick={() => {
+                                setShowFeedbackForm(false);
+                                setShowWorkoutModal(false);
+                                resetFeedbackForm();
+                              }}
+                            >
+                              Skip
+                            </button>
+                            <button
+                              className="btn-submit-feedback"
+                              onClick={() => submitFeedback(workoutDetail.date)}
+                              disabled={feedbackRating === 0 || submittingFeedback}
+                            >
+                              {submittingFeedback ? 'Submitting...' : 'Submit Feedback'}
+                            </button>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* ── MODAL ACTIONS (hidden while feedback form is open) ── */}
+                      {!showFeedbackForm && (
+                        <div className="modal-actions">
+                          {/* Completed + feedback already given */}
+                          {workoutDetail.session_status === 'completed' &&
+                            workoutDetail.has_feedback && (
+                              <div className="workout-completed-label">
+                                ✅ Completed · Feedback Given ✓
+                              </div>
+                            )}
+
+                          {/* Completed + no feedback yet */}
+                          {workoutDetail.session_status === 'completed' &&
+                            !workoutDetail.has_feedback && (
+                              <div className="completed-no-feedback-row">
+                                <div className="workout-completed-label">✅ Completed</div>
+                                <button
+                                  className="btn-add-feedback"
+                                  onClick={() => setShowFeedbackForm(true)}
+                                >
+                                  📝 Rate this Workout
+                                </button>
+                              </div>
+                            )}
+
+                          {/* No session yet */}
+                          {!workoutDetail.session_status && (
+                            <button
+                              className="btn-start-workout"
+                              onClick={async () => {
+                                try {
+                                  await startSession(workoutDetail.date);
+                                  showSuccess('Workout started!');
+                                  await fetchSchedule();
+                                  await fetchWorkoutForDate(workoutDetail.date);
+                                } catch {
+                                  showError('Could not start workout.');
+                                }
+                              }}
+                            >
+                              ▶️ Start Workout
+                            </button>
+                          )}
+
+                          {/* In progress */}
+                          {workoutDetail.session_status === 'in_progress' && (
+                            <button
+                              className="btn-complete-workout"
+                              onClick={async () => {
+                                try {
+                                  await completeSession(workoutDetail.date);
+                                  showSuccess('Workout completed! 🎉');
+                                  await fetchSchedule();
+                                  await fetchWorkoutForDate(workoutDetail.date);
+                                  setShowFeedbackForm(true);
+                                } catch {
+                                  showError('Could not complete workout.');
+                                }
+                              }}
+                            >
+                              ✅ Complete
+                            </button>
                           )}
                         </div>
-                      ))}
-
-                    <div className="modal-actions">
-                      {/* Completed state */}
-                      {workoutDetail.session_status === 'completed' && (
-                        <div className="workout-completed-label">✅ Completed</div>
                       )}
-
-                      {/* No session yet -> show Start */}
-                      {!workoutDetail.session_status && (
-                        <button
-                          className="btn-start-workout"
-                          onClick={async () => {
-                            try {
-                              await startSession(workoutDetail.date);
-                              showSuccess('Workout started!');
-                              await fetchSchedule();
-                              await fetchWorkoutForDate(workoutDetail.date);
-                            } catch (e) {
-                              showError('Could not start workout.');
-                            }
-                          }}
-                        >
-                          ▶️ Start Workout
-                        </button>
-                      )}
-
-                      {/* In progress -> ONLY show Complete (no Continue button) */}
-                      {workoutDetail.session_status === 'in_progress' && (
-                        <button
-                          className="btn-complete-workout"
-                          onClick={async () => {
-                            try {
-                              await completeSession(workoutDetail.date);
-                              showSuccess('Workout completed!');
-                              await fetchSchedule();
-                              await fetchWorkoutForDate(workoutDetail.date);
-                            } catch {
-                              showError('Could not complete workout.');
-                            }
-                          }}
-                        >
-                          ✅ Complete
-                        </button>
-                      )}
-                    </div>
-
                     </>
                   )}
                 </div>
@@ -659,7 +768,7 @@ const completeSession = async (dateStr: string) => {
           ) : null}
         </div>
 
-        {/* Notification Component */}
+        {/* Notification */}
         {notification && (
           <Notification
             type={notification.type}
@@ -668,7 +777,7 @@ const completeSession = async (dateStr: string) => {
           />
         )}
 
-        {/* Confirmation Modal for Deactivate */}
+        {/* Confirm deactivate */}
         {showDeactivateConfirm && (
           <ConfirmModal
             title="Clear Entire Schedule?"

--- a/frontend/src/app/schedule/schedule.css
+++ b/frontend/src/app/schedule/schedule.css
@@ -721,6 +721,14 @@
   margin-top: 0.20rem;
 }
 
+.program-focus-line {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.3rem;
+  margin-top: 0.2rem;
+}
+
 /* use to show # of exercises */
 .program-exercises-col {
   display:none;
@@ -844,12 +852,17 @@
 }
 
 .workout-completed-label {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffffff;
   background: #4caf50;
-  color: white;
-  font-weight: 800;
-  padding: 0.6rem 1rem;
+  padding: 0.75rem 2rem;
   border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
+
 
 .program-name-line {
   display: flex;
@@ -858,24 +871,233 @@
 }
 
 .program-complete-badge {
-  background: #4caf50;
-  color: white;
   font-size: 0.7rem;
   font-weight: 700;
-  padding: 0.15rem 0.3rem;
-  border-radius: 5px;
-  white-space: nowrap;
+  color: #ffffff;
+  background: #4caf50;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  display: inline-block;
 }
 
-.program-inprogress-badge{
-  background: #f59e0b; /* amber */
-  color: white;
+.program-inprogress-badge {
   font-size: 0.7rem;
-  font-weight: 600;
-  padding: 0.25rem 0.3rem;
-  border-radius: 6px;
-  white-space: nowrap;
+  font-weight: 700;
+  color: #ffffff;
+  background: #FF9234;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  display: inline-block;
 }
 
 
+/* ============================================================================
+   FEEDBACK FORM
+   ============================================================================ */
+
+.feedback-form {
+  background: var(--bg-tertiary);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.feedback-section {
+  margin-bottom: 1.5rem;
+}
+
+.feedback-section-inline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.feedback-label {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.75rem;
+}
+
+.feedback-required {
+  color: var(--fitiva-red);
+  margin-left: 2px;
+}
+
+.feedback-optional {
+  color: var(--text-tertiary);
+  font-weight: 400;
+  font-size: 0.8rem;
+}
+
+/* Rating buttons (difficulty + fatigue) */
+.rating-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.rating-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  border: 2px solid var(--border-medium);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rating-btn:hover {
+  border-color: var(--fitiva-red);
+  color: var(--fitiva-red);
+}
+
+.rating-btn-active {
+  background: linear-gradient(135deg, #EF3E36 0%, #FF9234 100%);
+  border-color: transparent;
+  color: white;
+  box-shadow: 0 2px 8px rgba(239, 62, 54, 0.35);
+}
+
+.rating-scale-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+/* Pain toggle */
+.toggle-pain-btn {
+  padding: 0.5rem 1.25rem;
+  border-radius: 20px;
+  border: 2px solid var(--border-medium);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.toggle-pain-yes {
+  border-color: #f44336;
+  background: rgba(244, 67, 54, 0.1);
+  color: #f44336;
+}
+
+.toggle-pain-no:hover {
+  border-color: var(--border-dark);
+  color: var(--text-primary);
+}
+
+/* Notes textarea */
+.feedback-textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--border-medium);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 80px;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+}
+
+.feedback-textarea:focus {
+  outline: none;
+  border-color: var(--fitiva-red);
+}
+
+.feedback-textarea::placeholder {
+  color: var(--text-tertiary);
+}
+
+/* Feedback action buttons */
+.feedback-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.btn-submit-feedback {
+  flex: 1;
+  padding: 0.875rem 1.5rem;
+  background: linear-gradient(135deg, #EF3E36 0%, #FF9234 100%);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 700;
+  transition: all 0.2s;
+  box-shadow: 0 4px 12px rgba(239, 62, 54, 0.3);
+}
+
+.btn-submit-feedback:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(239, 62, 54, 0.4);
+}
+
+.btn-submit-feedback:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn-skip-feedback {
+  padding: 0.875rem 1.5rem;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 2px solid var(--border-medium);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  transition: all 0.2s;
+}
+
+.btn-skip-feedback:hover {
+  border-color: var(--border-dark);
+  color: var(--text-primary);
+}
+
+/* Completed state variants */
+.workout-completed-label {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffffff;
+  background: #4caf50;
+  padding: 0.75rem 2rem;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.completed-no-feedback-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.btn-add-feedback {
+  padding: 0.6rem 1.25rem;
+  background: transparent;
+  border: 2px solid var(--border-medium);
+  color: var(--text-secondary);
+}
 


### PR DESCRIPTION
- Add WorkoutFeedback GET/POST endpoint at /api/sessions/feedback/<date>/
- Add trainer aggregated feedback endpoint at /api/trainer/programs/<id>/feedback/ (backend ready for US2.4, frontend pending)
- Update /api/schedule/active/ and /api/schedule/workout/<date>/ to return has_feedback bool
- Fix WorkoutFeedbackSerializer: mark session and id as read_only
- Add feedback form to schedule workout modal (difficulty required, fatigue/pain/notes optional)
- Feedback auto-prompts after completing a workout; skippable at any time
- Completed days show Feedback Given or Rate this Workout button based on state
- Fix status/feedback badges on calendar tiles to display on their own line
- Fix completed label contrast (white text on green background)
- Fix get_workout_for_date: total_exercises used wrong key w[session] instead of w[section]
- Add /app/node_modules anonymous volume to docker-compose to prevent recharts resolution failure