### PR TITLE
fix: serialize repository return values to dicts instead of model ins…

### DIFF
--- a/backend/repository/db_repository.py
+++ b/backend/repository/db_repository.py
@@ -64,10 +64,14 @@ class DBRepository(BaseRepository):
         return serializer.data
 
     def get_user_profile(self, user_id):
-        return UserProfile.objects.filter(user_id=user_id).first()
+        profile = UserProfile.objects.get(user_id=user_id)
+        return UserProfileSerializer(profile).data  # return dict, not model
 
     def get_trainer_profile(self, user_id):
-        return TrainerProfile.objects.filter(user_id=user_id).first()
+        profile = TrainerProfile.objects.filter(user_id=user_id).first()
+        if not profile:
+            return None
+        return TrainerProfileSerializer(profile).data
 
     def get_public_profile(self, user_id, requesting_user_id=None):
         user = User.objects.filter(id=user_id).first()
@@ -169,7 +173,10 @@ class DBRepository(BaseRepository):
         return {"total": qs.count(), "exercises": ExerciseTemplateSerializer(qs, many=True).data}
 
     def get_exercise_template_by_id(self, template_id):
-        return ExerciseTemplate.objects.filter(id=template_id).first()
+        template = ExerciseTemplate.objects.filter(id=template_id).first()
+        if not template:
+            return None
+        return ExerciseTemplateSerializer(template).data
 
     # ── Sections / Exercises ──────────────────────────────────────────────
 
@@ -189,7 +196,7 @@ class DBRepository(BaseRepository):
         schedule = UserSchedule.objects.filter(user_id=user_id, is_active=True).first()
         if not schedule:
             return {"message": "No active schedule found", "schedule": None, "calendar_events": []}
-        return schedule  # return the model instance; views.py will serialize it
+        return schedule  # return raw model, views.py serializes this manually anyways
 
     def check_program_in_schedule(self, user_id, program_id):
         schedule = UserSchedule.objects.filter(user_id=user_id, is_active=True).first()
@@ -213,7 +220,12 @@ class DBRepository(BaseRepository):
         return {"total": qs.count(), "sessions": WorkoutSessionSerializer(qs, many=True).data}
 
     def get_workout_feedback(self, user_id, date_str):
+        from api.serializers import WorkoutFeedbackSerializer
+        
         session = WorkoutSession.objects.filter(user_id=user_id, date=date_str).first()
         if not session:
             return None
-        return WorkoutFeedback.objects.filter(session=session).first()
+        feedback = WorkoutFeedback.objects.filter(session=session).first()
+        if not feedback:
+            return None
+        return WorkoutFeedbackSerializer(feedback).data

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -218,7 +218,11 @@ export default function DashboardPage() {
     const checkProfile = async () => {
       try {
         const profile = await profileAPI.getProfile();
-        setHasCompletedProfile(!!profile.age);
+        const isComplete =
+        !!profile.experience_level &&
+        !!profile.training_location &&
+        (profile.fitness_focus?.length ?? 0) > 0;
+        setHasCompletedProfile(isComplete);
       } catch {
         setHasCompletedProfile(false);
       } finally {

--- a/frontend/src/app/profile/[id]/page.tsx
+++ b/frontend/src/app/profile/[id]/page.tsx
@@ -594,7 +594,10 @@ export default function ProfileViewPage() {
                     <p className="program-description">{program.description}</p>
                     <div className="program-meta">
                       <span className="program-badge">{program.difficulty}</span>
-                      <span className="program-badge">{program.focus}</span>
+                      {program.focus.map((f) => (
+                        <span key={f} className="program-badge">{f}</span>
+                      ))}
+
                     </div>
                     <div className="program-details">
                       <span>{program.weekly_frequency}x per week</span>


### PR DESCRIPTION
…tances

Fixed get_trainer_profile, get_exercise_template_by_id, get_user_profile, and get_workout_feedback in DBRepository to return serialized dicts instead of raw Django model instances, matching the stub repository's return format. Also fixed hasCompletedProfile condition in dashboard to check experience_level, training_location, and fitness_focus instead of age, since age is optional. Left auth methods (get_user_by_id, get_user_by_username, get_user_by_email) and get_active_schedule as raw model returns intentionally — auth requires model instances for Django's login system, and the schedule view is too deeply ORM-coupled to safely refactor at this stage.